### PR TITLE
Fix no support in IDEA 14

### DIFF
--- a/src/java/main/vektah/rust/RustSyntaxHighlighter.java
+++ b/src/java/main/vektah/rust/RustSyntaxHighlighter.java
@@ -49,13 +49,11 @@ public class RustSyntaxHighlighter extends SyntaxHighlighterBase {
 	public static final TextAttributesKey[] EMPTY_KEYS = new TextAttributesKey[0];
 
 	@NotNull
-	@Override
 	public Lexer getHighlightingLexer() {
 		return new FlexAdapter(new RustLexer((Reader) null));
 	}
 
 	@NotNull
-	@Override
 	public TextAttributesKey[] getTokenHighlights(IElementType type) {
 		if (type == KW_AS |
 			type == KW_BREAK |

--- a/src/java/main/vektah/rust/ide/builder/RustCompilerDriver.java
+++ b/src/java/main/vektah/rust/ide/builder/RustCompilerDriver.java
@@ -81,7 +81,7 @@ public class RustCompilerDriver {
 
 		saveAndCommit(isUnitTestMode);
 
-		final CompileContextImpl compileContext = new CompileContextImpl(myProject, compileTask, scope, null, !isRebuild && !forceCompile, isRebuild);
+		final CompileContextImpl compileContext = new CompileContextImpl(myProject, compileTask, scope, !isRebuild && !forceCompile, isRebuild);
 
 		executeCompileTask(scope, isRebuild, forceCompile, callback, message, checkCachesVersion, compileTask, compileContext);
 	}

--- a/src/java/main/vektah/rust/ide/builder/RustCompilerManager.java
+++ b/src/java/main/vektah/rust/ide/builder/RustCompilerManager.java
@@ -13,8 +13,8 @@ public class RustCompilerManager extends CompilerManagerImpl {
 	private final Project project;
 	private final CompilationStatusListener myEventPublisher;
 
-	public RustCompilerManager(Project project, CompilerConfigurationImpl compilerConfiguration, MessageBus messageBus) {
-		super(project, compilerConfiguration, messageBus);
+	public RustCompilerManager(Project project, MessageBus messageBus) {
+		super(project, messageBus);
 
 		this.project = project;
 		this.myEventPublisher = messageBus.syncPublisher(CompilerTopics.COMPILATION_STATUS);


### PR DESCRIPTION
I'm not sure if this is necessarily IDEA 14-related or not, but this fixes my issue with #9. Please merge with caution!

As you can see, I simply removed a few things. From the compiler manager I removed the compiler configuration and such so that the signature matched the signature of `CompilerManagerImpl`. The old (current master) `super()` call must have been removed or something, breaking the API.

Same thing goes for instantiating the `CompileContextImpl` in `RustCompilerDriver` -- looks like they simply removed a parameter.